### PR TITLE
#19 Expose formatting function

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -2,7 +2,7 @@ import component from './component'
 import defaultOptions from './defaultOptions'
 import directive from './directive'
 import createCurrencyFormat from './utils/createCurrencyFormat'
-import { parse } from './utils/formatHelper'
+import { parse, format } from './utils/formatHelper'
 
 const plugin = {
   install (Vue, {
@@ -16,6 +16,9 @@ const plugin = {
     Vue.directive(directiveName, directive)
     Vue.prototype.$parseCurrency = (str, locale = options.locale, currency = options.currency) => {
       return parse(str, createCurrencyFormat({ ...options, locale, currency }))
+    }
+    Vue.prototype.$formatCurrency = (num, locale = options.locale, currency = options.currency) => {
+      return format(num, createCurrencyFormat({ ...options, locale, currency }))
     }
   }
 }

--- a/src/utils/createCurrencyFormat.js
+++ b/src/utils/createCurrencyFormat.js
@@ -15,6 +15,7 @@ export default ({ locale, currency, min }) => {
     decimalSymbol,
     decimalLimit,
     allowDecimal,
-    allowNegative
+    allowNegative,
+    locale
   }
 }

--- a/src/utils/formatHelper.js
+++ b/src/utils/formatHelper.js
@@ -58,3 +58,13 @@ export const parse = (str, { prefix, suffix, thousandsSeparatorSymbol, decimalSy
   }
   return null
 }
+
+export const format = (num, { prefix, suffix, thousandsSeparatorSymbol, decimalSymbol, decimalLimit, locale } = {}) => {
+  if (typeof num === 'string') {
+    return num
+  } else if (num && typeof num === 'number') {
+    let value = new Intl.NumberFormat(locale, { minimumFractionDigits: decimalLimit }).format(num)
+    return prefix + value + suffix
+  }
+  return null
+}


### PR DESCRIPTION
Suggestive fix for #19 

Example usage:

```
<template>
    <el-input v-model="internalValue" v-currency="options" class="currency-input"/>
</template>
<script>
    export default {
        props: ['value', 'currency'],
        components: {},
        data: function () {
            return {
                options: {
                    locale: 'el',
                    currency: this.currency,
                    distractionFree: true,
                    validateOnInput: false
                },
                internalValue: null
            }
        },
        watch: {
            value(newValue, oldValue) {
                // only format when value is set programmatically, not typed in  by user
                if (oldValue == null && newValue != null && this.internalValue == null) {
                    this.internalValue = this.$formatCurrency(newValue, this.options.locale, this.options.currency)
                } else {
                    this.internalValue = newValue
                }
            },
            internalValue(newValue) {
                this.$emit('input', this.$parseCurrency(newValue, this.options.locale, this.options.currency))
            }
        }
    }
</script>
```