### PR TITLE
Export the parse and createCurrencyFormat function

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -23,3 +23,4 @@ const plugin = {
 export default plugin
 export { component as CurrencyInput }
 export { directive as CurrencyDirective }
+export { parse, createCurrencyFormat };


### PR DESCRIPTION
In our situation, we don't want to register the plugin globally as most of the pages are not using it. Therefore we go with directive solution which allows you to import this currency input on demand. However, this means we need to implement our own `parseCurrency` method and we can't config the default currency and locale (The default locale configuration is passed in as a parameter when the library is registered globally). When we creating our own `parseCurrency` function, we find that `parse` and  `createCurrencyFormat` in the `parseCurrency` implementation is not exported. This pull request is to export these two functions so we can create our own `parseCurrency` function