### PR TITLE
Add new options 'hideCurrencySymbol' and 'hideGroupingSymbol'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Automatically insert the decimal symbol and use the last inputted digits as deci
 ### Distraction free
 Automatically hide the formatting and negligible decimal digits on focus.
 
+### Hide currency symbol
+Hide currency symbol in non-focused mode and on focus as well.
+
+### Hide grouping symbol
+Hide grouping symbol in non-focused mode and on focus as well.
+
 ## Support me
 If you find this plugin helpful or you want to support the development, buy me a coffee:
 

--- a/demo/ComponentDemo.vue
+++ b/demo/ComponentDemo.vue
@@ -95,6 +95,8 @@ export default {
     locale: undefined,
     autoDecimalMode: false,
     distractionFree: true,
+    hideCurrencySymbol: false,
+    hideGroupingSymbol: false,
     min: null,
     max: null
   })

--- a/docs/.vuepress/components/HideCurrencySymbol.vue
+++ b/docs/.vuepress/components/HideCurrencySymbol.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="demo">
+    <CurrencyInput
+      v-model="value"
+      :distraction-free="false"
+      :hide-currency-symbol="hideCurrencySymbol"
+      class="demo__currency-input"/>
+    <div class="demo__options">
+      <p>
+        <label>
+          <input
+            v-model="hideCurrencySymbol"
+            type="checkbox">
+          <span>Always hide currency symbol</span>
+        </label>
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'HideCurrencySymbol',
+  data: () => ({
+    value: 1234.5,
+    hideCurrencySymbol: false
+  })
+}
+</script>

--- a/docs/.vuepress/components/HideGroupingSymbol.vue
+++ b/docs/.vuepress/components/HideGroupingSymbol.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="demo">
+    <CurrencyInput
+      v-model="value"
+      :distraction-free="false"
+      :hide-grouping-symbol="hideGroupingSymbol"
+      class="demo__currency-input"/>
+    <div class="demo__options">
+      <p>
+        <label>
+          <input
+            v-model="hideGroupingSymbol"
+            type="checkbox">
+          <span>Always hide grouping symbol</span>
+        </label>
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'HideGroupingSymbol',
+  data: () => ({
+    value: 1234.5,
+    hideGroupingSymbol: false
+  })
+}
+</script>

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,5 +11,7 @@ features:
   details: Language-dependent, ISO-compliant currency formatting.
 - title: Distraction free
   details: Automatically hide the formatting and negligible decimal digits on focus.
+- title: Hide Currency and/or Grouping symbols
+  details: Automatically hide currency and or grouping symbols for non-focused mode and on focus as well.
 footer: MIT Licensed | Copyright © Matthias Stiller 
 ---

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -14,6 +14,8 @@ Name | Type | Description
 `auto-decimal-mode` | Boolean | Whether the decimal symbol is inserted automatically, using the last inputted digits as decimal digits. Default is `false` (the decimal symbol needs to be inserted manually).
 `decimal-length` | Number | The number of displayed decimal digits. Default is `undefined` (use the currency's default). Must be between 0 and 20 and can only be applied for currencies that support decimal digits.
 `distraction-free` | Boolean/Object | Whether to hide negligible decimal digits, the currency symbol and the grouping symbol on focus. Default is `true`. You can also pass an object of boolean properties to configure each option: `{hideNegligibleDecimalDigits, hideCurrencySymbol, hideGroupingSymbol}` (see [examples](/examples/#distraction-free-mode)). Using `false` will leave the formatted value untouched on focus.
+`hide-currency-symbol` | Boolean | Always hide currency symbol (doesn't matter if input is focused or not). Default is `false`.
+`hide-grouping-symbol` | Boolean | Alwats Hide grouping symbol (doesn't matter if input is focused or not). Default is `false`.
 `min` | Number | Minimum value. Default is `null` (no limitation). Must be less than `max`.
 `max` | Number | Maximum value. Default is `null` (no limitation). Must be greater than `min`.
 
@@ -28,6 +30,8 @@ The `v-currency` directive supports the same options as the `<currency-input>` c
     autoDecimalMode: false,
     decimalLength: undefined,
     distractionFree: true,
+    hideCurrencySymbol: false,
+    hideGroupingSymbol: false,
     min: null,
     max: null
   }"/>

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -30,6 +30,18 @@ Hide various parts of the formatting on focus.
 
 [View source](https://github.com/dm4t2/vue-currency-input/blob/master/docs/.vuepress/components/DistractionFree.vue)
 
+## Hide currency symbol
+Always hide currency symbol (doesn't matter if input is focused or not).
+<HideCurrencySymbol/>
+
+[View source](https://github.com/dm4t2/vue-currency-input/blob/master/docs/.vuepress/components/HideCurrencySymbol.vue)
+
+## Hide grouping symbol
+Alwats hide grouping symbol (doesn't matter if input is focused or not).
+<HideGroupingSymbol/>
+
+[View source](https://github.com/dm4t2/vue-currency-input/blob/master/docs/.vuepress/components/HideGroupingSymbol.vue)
+
 ## Value range
 Limitation of the entered value range.
 <ValueRange/>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-currency-input",
   "description": "Easy input of currency formatted numbers for Vue.js.",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "license": "MIT",
   "unpkg": "dist/vue-currency-input.umd.js",
   "jsdelivr": "dist/vue-currency-input.umd.js",

--- a/src/component.js
+++ b/src/component.js
@@ -44,6 +44,14 @@ export default {
       type: Boolean,
       default: undefined
     },
+    hideCurrencySymbol: {
+      type: Boolean,
+      default: false
+    },
+    hideGroupingSymbol: {
+      type: Boolean,
+      default: false
+    },
     min: {
       type: Number,
       default: undefined

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -4,6 +4,8 @@ export default {
   distractionFree: true,
   decimalLength: undefined,
   autoDecimalMode: false,
+  hideCurrencySymbol: false,
+  hideGroupingSymbol: false,
   min: null,
   max: null
 }

--- a/src/utils/caretPosition.js
+++ b/src/utils/caretPosition.js
@@ -18,18 +18,18 @@ export const getCaretPositionAfterFormat = (el, inputtedValue, caretPosition) =>
         caretPositionFromLeft -= 1
       }
     }
-    return el.$ci.options.hideCurrencySymbol
+    return el.$ci.options.hideCurrencySymbolOnFocus
       ? newValue.length - caretPositionFromLeft
       : Math.max(newValue.length - Math.max(caretPositionFromLeft, suffix.length), prefix.length === 0 ? 0 : prefix.length + 1)
   }
 }
 
-export const getCaretPositionAfterApplyingDistractionFreeFormat = ({ prefix, groupingSymbol }, { hideCurrencySymbol, hideGroupingSymbol }, value, caretPosition) => {
+export const getCaretPositionAfterApplyingDistractionFreeFormat = ({ prefix, groupingSymbol }, { hideCurrencySymbolOnFocus, hideGroupingSymbolOnFocus }, value, caretPosition) => {
   let result = caretPosition
-  if (hideCurrencySymbol) {
+  if (hideCurrencySymbolOnFocus) {
     result -= prefix.length
   }
-  if (hideGroupingSymbol) {
+  if (hideGroupingSymbolOnFocus) {
     result -= count(value.substring(0, caretPosition), groupingSymbol)
   }
   return Math.max(0, result)

--- a/tests/unit/caretPosition.spec.js
+++ b/tests/unit/caretPosition.spec.js
@@ -42,7 +42,7 @@ describe('caretPosition', () => {
          * New value:       1,234|
          */
         it('returns the expected caret position', () => {
-          const el = { value: '1,234', $ci: { currencyFormat, options: { hideCurrencySymbol: true } } }
+          const el = { value: '1,234', $ci: { currencyFormat, options: { hideCurrencySymbolOnFocus: true } } }
           expect(getCaretPositionAfterFormat(el, '1234', 4)).toBe(5)
         })
       })
@@ -54,7 +54,7 @@ describe('caretPosition', () => {
          * New value:       1,234|.99
          */
         it('returns the expected caret position if the integer part is modified', () => {
-          const el = { value: '1,234.99', $ci: { currencyFormat, options: { hideCurrencySymbol: true } } }
+          const el = { value: '1,234.99', $ci: { currencyFormat, options: { hideCurrencySymbolOnFocus: true } } }
           expect(getCaretPositionAfterFormat(el, '1234.99', 4)).toBe(5)
         })
 
@@ -64,7 +64,7 @@ describe('caretPosition', () => {
          * New value:       1.0|9
          */
         it('returns the expected caret position if the fraction part is modified', () => {
-          const el = { value: '1.09', $ci: { currencyFormat, options: { hideCurrencySymbol: true } } }
+          const el = { value: '1.09', $ci: { currencyFormat, options: { hideCurrencySymbolOnFocus: true } } }
           expect(getCaretPositionAfterFormat(el, '1.099', 3)).toBe(3)
         })
 
@@ -74,7 +74,7 @@ describe('caretPosition', () => {
          * New value:       1.0|9
          */
         it('returns the expected caret position if the fraction part is extended', () => {
-          const el = { value: '1.09', $ci: { currencyFormat, options: { hideCurrencySymbol: true } } }
+          const el = { value: '1.09', $ci: { currencyFormat, options: { hideCurrencySymbolOnFocus: true } } }
           expect(getCaretPositionAfterFormat(el, '1.09', 3)).toBe(3)
         })
       })
@@ -88,7 +88,7 @@ describe('caretPosition', () => {
          * New value:       $1|
          */
         it('returns the expected caret position if new value is entered', () => {
-          const el = { value: '$1', $ci: { currencyFormat, options: { hideCurrencySymbol: false } } }
+          const el = { value: '$1', $ci: { currencyFormat, options: { hideCurrencySymbolOnFocus: false } } }
           expect(getCaretPositionAfterFormat(el, '1', 1)).toBe(2)
         })
       })
@@ -125,7 +125,7 @@ describe('caretPosition', () => {
        * New value:       1,234,|768
        */
       it('returns the caret position subtracted by the prefix length', () => {
-        expect(getCaretPositionAfterApplyingDistractionFreeFormat(currencyFormat, { hideCurrencySymbol: true, hideGroupingSymbol: false }, '$1,234,768', 7)).toBe(6)
+        expect(getCaretPositionAfterApplyingDistractionFreeFormat(currencyFormat, { hideCurrencySymbolOnFocus: true, hideGroupingSymbolOnFocus: false }, '$1,234,768', 7)).toBe(6)
       })
     })
 
@@ -135,7 +135,7 @@ describe('caretPosition', () => {
        * New value:       $1|234768
        */
       it('returns the current caret position if before the first grouping symbol', () => {
-        expect(getCaretPositionAfterApplyingDistractionFreeFormat(currencyFormat, { hideCurrencySymbol: false, hideGroupingSymbol: true }, '$1,234,768', 2)).toBe(2)
+        expect(getCaretPositionAfterApplyingDistractionFreeFormat(currencyFormat, { hideCurrencySymbolOnFocus: false, hideGroupingSymbolOnFocus: true }, '$1,234,768', 2)).toBe(2)
       })
 
       /**
@@ -143,7 +143,7 @@ describe('caretPosition', () => {
        * New value:       $1234|768
        */
       it('returns the caret position subtracted by the respective number of grouping symbols', () => {
-        expect(getCaretPositionAfterApplyingDistractionFreeFormat(currencyFormat, { hideCurrencySymbol: false, hideGroupingSymbol: true }, '$1,234,768', 7)).toBe(5)
+        expect(getCaretPositionAfterApplyingDistractionFreeFormat(currencyFormat, { hideCurrencySymbolOnFocus: false, hideGroupingSymbolOnFocus: true }, '$1,234,768', 7)).toBe(5)
       })
     })
 
@@ -153,7 +153,7 @@ describe('caretPosition', () => {
        * New value:       $1,234,|768
        */
       it('returns the expected caret position', () => {
-        expect(getCaretPositionAfterApplyingDistractionFreeFormat(currencyFormat, { hideCurrencySymbol: false, hideGroupingSymbol: false }, '$1,234,768', 7)).toBe(7)
+        expect(getCaretPositionAfterApplyingDistractionFreeFormat(currencyFormat, { hideCurrencySymbolOnFocus: false, hideGroupingSymbolOnFocus: false }, '$1,234,768', 7)).toBe(7)
       })
     })
 
@@ -163,7 +163,7 @@ describe('caretPosition', () => {
        * New value:       12|34768
        */
       it('returns the expected caret position', () => {
-        expect(getCaretPositionAfterApplyingDistractionFreeFormat(currencyFormat, { hideCurrencySymbol: true, hideGroupingSymbol: true }, '$1,234,768', 4)).toBe(2)
+        expect(getCaretPositionAfterApplyingDistractionFreeFormat(currencyFormat, { hideCurrencySymbolOnFocus: true, hideGroupingSymbolOnFocus: true }, '$1,234,768', 4)).toBe(2)
       })
     })
   })

--- a/tests/unit/component.spec.js
+++ b/tests/unit/component.spec.js
@@ -183,6 +183,56 @@ describe('CurrencyInput', () => {
 
         expect(wrapper.element.selectionStart).toBe(3)
       })
+
+      describe('hide currency symbol tests', () => {
+        it('shows the currency symbol when focused', () => {
+          const wrapper = mountComponent({ locale: 'en', currency: 'EUR', hideCurrencySymbol: false, distractionFree: false })
+          wrapper.setValue('4242.42')
+          wrapper.trigger('focus')
+          jest.runOnlyPendingTimers()
+          expect(wrapper.element.value).toBe('€4,242.42')
+        })
+
+        it('hide currency symbol is enabled when focused', () => {
+          const wrapper = mountComponent({ locale: 'en', currency: 'EUR', hideCurrencySymbol: true, distractionFree: false })
+          wrapper.setValue('4242.42')
+          wrapper.trigger('focus')
+          jest.runOnlyPendingTimers()
+          expect(wrapper.element.value).toBe('4,242.42')
+        })
+
+        it('hide currency symbol is enabled when blurred', () => {
+          const wrapper = mountComponent({ locale: 'en', currency: 'EUR', hideCurrencySymbol: true, distractionFree: false })
+          wrapper.setValue('4242.42')
+          jest.runOnlyPendingTimers()
+          expect(wrapper.element.value).toBe('4,242.42')
+        })
+      })
+
+      describe('hide grouping symbol tests', () => {
+        it('shows the grouping symbol when focused', () => {
+          const wrapper = mountComponent({ locale: 'en', currency: 'EUR', hideGroupingSymbol: false, distractionFree: false })
+          wrapper.setValue('4242.42')
+          wrapper.trigger('focus')
+          jest.runOnlyPendingTimers()
+          expect(wrapper.element.value).toBe('€4,242.42')
+        })
+
+        it('hide grouping symbol when focused', () => {
+          const wrapper = mountComponent({ locale: 'en', currency: 'EUR', hideGroupingSymbol: true, distractionFree: false })
+          wrapper.setValue('4242.42')
+          wrapper.trigger('focus')
+          jest.runOnlyPendingTimers()
+          expect(wrapper.element.value).toBe('€4242.42')
+        })
+
+        it('hide grouping symbol when blurred', () => {
+          const wrapper = mountComponent({ locale: 'en', currency: 'EUR', hideGroupingSymbol: true, distractionFree: false })
+          wrapper.setValue('4242.42')
+          jest.runOnlyPendingTimers()
+          expect(wrapper.element.value).toBe('€4242.42')
+        })
+      })
     })
   })
 


### PR DESCRIPTION
The goal here is allow the component to behave as a simple decimal input as well.

    - feat: add new config options 'hideCurrencySymbol' and 'hideGroupingSymbol' for non-focused mode, allowing this component to behave as Decimal Input as well

    - test: add new unit tests in favor of new options 'hideCurrencySymbol' and 'hideGroupingSymbol'

    - doc: update docs to include new options 'hideCurrencySymbol' and 'hideGroupingSymbol'

    - chore: just add new options to small demo

    - misc: bump version to 1.9.2
