### PR TITLE
Update vue-demi for Vue 2.7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "windicss": "^3.4.4"
   },
   "dependencies": {
-    "vue-demi": "^0.12.1"
+    "vue-demi": "^0.13.1"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8820,10 +8820,10 @@ vitepress@^0.22.3:
     vite "^2.8.1"
     vue "^3.2.31"
 
-vue-demi@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.12.1.tgz#f7e18efbecffd11ab069d1472d7a06e319b4174c"
-  integrity sha512-QL3ny+wX8c6Xm1/EZylbgzdoDolye+VpCXRhI2hug9dJTP3OUJ3lmiKN3CsVV3mOJKwFi0nsstbgob0vG7aoIw==
+vue-demi@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.13.1.tgz#7604904c88be338418a10abbc94d5b8caa14cb8c"
+  integrity sha512-xmkJ56koG3ptpLnpgmIzk9/4nFf4CqduSJbUM0OdPoU87NwRuZ6x49OLhjSa/fC15fV+5CbEnrxU4oyE022svg==
 
 vue-eslint-parser@^8.0.0:
   version "8.3.0"


### PR DESCRIPTION
Vue 2.7 has backported some parts of Vue 3.0, including the composition API.

This bumps the `vue-demi` dependency to `^0.13.1` to take advantage of these changes.