### PR TITLE
adds type module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dist/*.js",
     "dist/index.d.ts"
   ],
+  "type": "module",
   "exports": {
     ".": {
       "import": "./dist/index.esm.js",


### PR DESCRIPTION
I was stuck trying to running my tests and getting this error:

````
SyntaxError: Named export 'useCurrencyInput' not found. The requested module 'vue-currency-input' is a CommonJS module, witch may not support all module.exports as named exports. CommonJS modules can always be imported via the default export....
````

![image](https://user-images.githubusercontent.com/1690400/198717004-46f33180-aad1-40ba-9423-294996b9d7aa.png)

Adding `"type": "module"` to the `package.json` solved the problem.

Do you see any issue in doing this?