### PR TITLE
handle-accounting-sign-on-tab-key-focus

### DIFF
--- a/src/currencyInput.ts
+++ b/src/currencyInput.ts
@@ -158,6 +158,7 @@ export class CurrencyInput {
       }
       if (this.maxValue <= 0 && !this.currencyFormat.isNegative(formattedValue) && this.currencyFormat.parse(formattedValue) !== 0) {
         formattedValue = formattedValue.replace(this.currencyFormat.prefix, this.currencyFormat.negativePrefix)
+        formattedValue = formattedValue.length ? `${formattedValue})` : formattedValue
       }
       if (this.minValue >= 0) {
         formattedValue = formattedValue.replace(this.currencyFormat.negativePrefix, this.currencyFormat.prefix)
@@ -216,6 +217,9 @@ export class CurrencyInput {
                 }
               }
             }
+          }
+          if (selectionStart === 1 && caretPositionFromLeft === 0 && this.formattedValue.endsWith(')')) {
+            caretPositionFromLeft = 1
           }
           return this.options.hideCurrencySymbolOnFocus || this.options.currencyDisplay === CurrencyDisplay.hidden
             ? newValueLength - caretPositionFromLeft


### PR DESCRIPTION
Hi. I have spotted an issue relating to the usage of the _accounting sign_. It is a case when you focus a field using the **TAB** key. Whenever you TAB into an input field (whole text gets selected), whatever you is being typed in there will first discard the last (closing) parenthesis and  as the typing continues the caret uncontrollably shifts its location. I would like you in this respect to consider this MR as it resolves the issue.