### PR TITLE
Add example of integration with FormKit

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -6,3 +6,6 @@
 ## Element Plus
 [![Vue Currency Input: Integration with Element Plus](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/vue-currency-input-integration-with-element-plus-devoxx)
 
+## FormKit
+
+[![Vue Currency Input: Integration FormKit](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/formkit-vue-currency-input-example-mgmvyn)


### PR DESCRIPTION
Its non-trivial to integrate `vue-currency-input` with FormKit, so its useful to have an example of how to do it. :)